### PR TITLE
removing extra MinApp API calls

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,6 @@
         </div>
       </div>
     </div>
-
   </div>
 
   <!-- Modal Login -->
@@ -219,7 +218,6 @@
       </div>
     </div>
   </div>
-
 </div>
 <script src="js/index.js"></script>
 </body>


### PR DESCRIPTION
* removing the unnecessary `getWithoutData` calls, replacing them with regular `id`s
* limiting how many events are loaded

Potential future refactoring:
* Only load `signup` and `attendee` info when requested by user